### PR TITLE
Upgrade node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN docker-php-source extract \
 && pecl config-set preferred_state stable \
 
 # Install node
-&& curl -sL https://deb.nodesource.com/setup_6.x | bash - \
+&& curl -sL https://deb.nodesource.com/setup_8.x | bash - \
 && apt-get install nodejs -y \
 && npm install -g bower \
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ RUN docker-php-source extract \
 # Install node
 && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
 && apt-get install nodejs -y \
-&& npm install -g bower \
 
 # Install yarn
 && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \


### PR DESCRIPTION
기존 node 버전(6.x)에서 지원되지 않는 ECMAScript 기능이 많아 8.x로 업그레이드했습니다. 그리고 bower 설치 스크립트가 중복돼있어 하나를 제거했습니다.